### PR TITLE
Add debug menu with FPS and day/night cycle information

### DIFF
--- a/Planned/index.html
+++ b/Planned/index.html
@@ -159,6 +159,29 @@
             border: 2px solid #ff4444;
             pointer-events: auto;
         }
+
+        /* Debug Menu Styles */
+        .debug-menu {
+            position: absolute;
+            top: 20px;
+            right: 80px;
+            color: #fff;
+            font-size: 14px;
+            background: rgba(0, 0, 0, 0.5);
+            padding: 10px;
+            border-radius: 8px;
+            backdrop-filter: blur(10px);
+            display: none;
+        }
+
+        .debug-menu.visible {
+            display: block;
+        }
+
+        .debug-menu div {
+            margin: 5px 0;
+            font-family: monospace;
+        }
     </style>
 </head>
 <body>
@@ -189,11 +212,17 @@
             <h2>Paused</h2>
             <button onclick="togglePause()">Resume</button>
             <button onclick="toggleSound()">Sound: ON</button>
+            <button onclick="toggleDebugMenu()">Debug Info: OFF</button>
         </div>
         
         <div class="crash-message" id="crash-message">
             CRASHED!<br>
             Press R to Reset
+        </div>
+
+        <div class="debug-menu" id="debug-menu">
+            <div id="fps-counter">FPS: 60</div>
+            <div id="day-night-state">Time: Day</div>
         </div>
     </div>
 

--- a/Planned/js/ui.js
+++ b/Planned/js/ui.js
@@ -3,6 +3,10 @@ class UISystem {
         this.speedometerCanvas = null;
         this.speedometerCtx = null;
         this.createSpeedometer();
+        this.lastFrameTime = performance.now();
+        this.frameCount = 0;
+        this.fps = 0;
+        this.debugEnabled = false;
     }
     
     createSpeedometer() {
@@ -129,10 +133,56 @@ class UISystem {
             crashMessage.style.display = 'none';
         }
     }
+
+    toggleDebugMenu() {
+        this.debugEnabled = !this.debugEnabled;
+        const debugMenu = document.getElementById('debug-menu');
+        const debugButton = document.querySelector('.pause-menu button:last-of-type');
+        
+        if (debugMenu) {
+            debugMenu.classList.toggle('visible', this.debugEnabled);
+        }
+        
+        if (debugButton) {
+            debugButton.textContent = `Debug Info: ${this.debugEnabled ? 'ON' : 'OFF'}`;
+        }
+    }
+
+    updateFPS() {
+        const currentTime = performance.now();
+        this.frameCount++;
+
+        if (currentTime - this.lastFrameTime >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFrameTime = currentTime;
+        }
+
+        if (this.debugEnabled) {
+            const fpsCounter = document.getElementById('fps-counter');
+            if (fpsCounter) {
+                fpsCounter.textContent = `FPS: ${this.fps}`;
+            }
+        }
+    }
+
+    updateDayNightState(skySystem) {
+        if (this.debugEnabled) {
+            const dayNightState = document.getElementById('day-night-state');
+            if (dayNightState && skySystem) {
+                const timeOfDay = skySystem.getTimeOfDay();
+                const timeStr = timeOfDay >= 0.25 && timeOfDay < 0.75 ? 'Day' : 'Night';
+                const percent = Math.round(timeOfDay * 100);
+                dayNightState.textContent = `Time: ${timeStr} (${percent}%)`;
+            }
+        }
+    }
     
-    update(aircraft) {
+    update(aircraft, skySystem) {
         this.updateSpeedometer(aircraft.speed);
         this.updateAltimeter(aircraft.altitude);
+        this.updateFPS();
+        this.updateDayNightState(skySystem);
     }
 }
 
@@ -146,5 +196,11 @@ function togglePause() {
 function toggleSound() {
     if (window.game && window.game.audioSystem) {
         window.game.audioSystem.toggleSound();
+    }
+}
+
+function toggleDebugMenu() {
+    if (window.game && window.game.uiSystem) {
+        window.game.uiSystem.toggleDebugMenu();
     }
 }

--- a/Planned/js/ui.js
+++ b/Planned/js/ui.js
@@ -7,6 +7,11 @@ class UISystem {
         this.frameCount = 0;
         this.fps = 0;
         this.debugEnabled = false;
+        
+        // Cache DOM elements
+        this.fpsCounter = document.getElementById('fps-counter');
+        this.dayNightState = document.getElementById('day-night-state');
+        this.debugMenu = document.getElementById('debug-menu');
     }
     
     createSpeedometer() {
@@ -136,11 +141,10 @@ class UISystem {
 
     toggleDebugMenu() {
         this.debugEnabled = !this.debugEnabled;
-        const debugMenu = document.getElementById('debug-menu');
         const debugButton = document.querySelector('.pause-menu button:last-of-type');
         
-        if (debugMenu) {
-            debugMenu.classList.toggle('visible', this.debugEnabled);
+        if (this.debugMenu) {
+            this.debugMenu.classList.toggle('visible', this.debugEnabled);
         }
         
         if (debugButton) {
@@ -156,25 +160,20 @@ class UISystem {
             this.fps = this.frameCount;
             this.frameCount = 0;
             this.lastFrameTime = currentTime;
-        }
 
-        if (this.debugEnabled) {
-            const fpsCounter = document.getElementById('fps-counter');
-            if (fpsCounter) {
-                fpsCounter.textContent = `FPS: ${this.fps}`;
+            // Only update the DOM when FPS is recalculated (once per second)
+            if (this.debugEnabled && this.fpsCounter) {
+                this.fpsCounter.textContent = `FPS: ${this.fps}`;
             }
         }
     }
 
     updateDayNightState(skySystem) {
-        if (this.debugEnabled) {
-            const dayNightState = document.getElementById('day-night-state');
-            if (dayNightState && skySystem) {
-                const timeOfDay = skySystem.getTimeOfDay();
-                const timeStr = timeOfDay >= 0.25 && timeOfDay < 0.75 ? 'Day' : 'Night';
-                const percent = Math.round(timeOfDay * 100);
-                dayNightState.textContent = `Time: ${timeStr} (${percent}%)`;
-            }
+        if (this.debugEnabled && this.dayNightState && skySystem) {
+            const timeOfDay = skySystem.getTimeOfDay();
+            const timeStr = timeOfDay >= 0.25 && timeOfDay < 0.75 ? 'Day' : 'Night';
+            const percent = Math.round(timeOfDay * 100);
+            this.dayNightState.textContent = `Time: ${timeStr} (${percent}%)`;
         }
     }
     
@@ -182,7 +181,11 @@ class UISystem {
         this.updateSpeedometer(aircraft.speed);
         this.updateAltimeter(aircraft.altitude);
         this.updateFPS();
-        this.updateDayNightState(skySystem);
+        
+        // Only update day/night state every second to avoid unnecessary DOM updates
+        if (this.frameCount === 0) {
+            this.updateDayNightState(skySystem);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a debug menu feature that includes:

- FPS counter display in the top-right corner
- Day/night cycle state display
- Toggle button in the pause menu to enable/disable the debug information
- Debug menu is disabled by default
- All debug information is displayed with a semi-transparent background for better visibility

The debug menu can be toggled on/off through the pause menu, and when enabled shows:
1. Current FPS (updates every second)
2. Current state of the day/night cycle with percentage